### PR TITLE
fix: Resolve minimatch ReDoS vulnerability

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -2,7 +2,7 @@
 
 ## Identity
 
-- Package: @forgespace/branding-mcp v0.2.0
+- Package: @forgespace/branding-mcp v0.3.0
 - GitHub: Forge-Space/branding-mcp
 - Local: ~/Desenvolvimento/forge-space/branding-mcp
 - Node.js 22, TypeScript, ESM
@@ -16,7 +16,7 @@
 
 ## Tools
 
-1. `generate_brand_identity` — Full brand system from keywords/description
+1. `generate_brand_identity` — Full brand system (colors + typography + spacing + shadows + borders + motion)
 2. `color_palette` — HSL color harmony with WCAG contrast
 3. `typography_system` — Modular type scale + font pairing
 4. `export_tokens` — Multi-format design token export (W3C JSON, CSS, Tailwind, Figma, React, Sass)
@@ -24,38 +24,48 @@
 6. `validate` — Brand consistency scoring + WCAG validation
 7. `refine_brand_element` — AI-powered natural language refinement
 
+## Generators (7 total)
+
+- `color-palette.ts` — HSL harmonies, WCAG contrast
+- `typography-system.ts` — Modular type scales, curated font pairings
+- `spacing-scale.ts` — Geometric spacing progression
+- `logo-generator.ts` — SVG text-based logos
+- `shadow-system.ts` — 6-level elevation, brand-tinted, light/dark themes (v0.3.0)
+- `border-system.ts` — Style-aware radii + border widths for all 8 brand styles (v0.3.0)
+- `motion-system.ts` — Durations, cubic-bezier easings, transition presets (v0.3.0)
+
 ## Resources
 
-- Templates catalog
-- Knowledge base
+- Templates catalog (`brand://templates`)
+- Knowledge base (`brand://knowledge`)
 
 ## Test & Coverage
 
-- 97.63% coverage, 8 suites, 97 tests
-- Generators: 98.16%, Validators: 97.36%, AI interpreters: 92.45%
+- 98.36% statement coverage, 100% function coverage, 89.72% branches
+- 11 suites, 133 tests
+- Generators: shadow (8), border (9), motion (10), plus exporter tests (9 new)
 
 ## CI Status
 
-- CI: passing (PR #5 merged — fixed Prettier formatting)
-- Security scan: passing
-- Release workflow: should pass now (was blocked by same Prettier issue)
+- CI: passing (PR #6 merged — v0.3.0 design system completeness)
+- Security scan: passing (trufflehog pinned to @v3.93.4, was @main)
+- Release: v0.3.0 tagged and released on GitHub
+- .gitignore expanded to 18 lines (was 7) — covers .uiforge/, .serena/, .claude/, SQLite
 
 ## Key Files
 
 - `src/index.ts` — MCP server entry + tool registration
 - `src/tools/` — 7 tool definitions with Zod schemas
-- `src/lib/branding-core/generators/` — Color, typography, spacing, logo
-- `src/lib/branding-core/exporters/` — 6 format exporters
+- `src/lib/branding-core/generators/` — 7 generators (color, typography, spacing, logo, shadow, border, motion)
+- `src/lib/branding-core/exporters/` — 6 format exporters (CSS, Tailwind, W3C JSON, Figma, React, Sass)
 - `src/lib/branding-core/validators/` — WCAG contrast, consistency
-- `src/ai/` — Brand interpretation layer (keyword/Claude/auto strategies)
+- `src/lib/branding-core/ai/` — Brand interpretation layer (keyword/Claude/auto strategies)
 
-## Next: v0.3.0 — Design System Completeness
+## Release History
 
-- Plan at `.claude/plans/design-system-completeness.md`
-- 3 new generators: shadow/elevation, border/shape, motion/animation
-- 1 new tool: `generate_design_system` (combines all generators)
-- All 6 exporters to be updated with new token types
-- Task claimed: `branding-mcp-feature-expansion` in queue
+- v0.1.0 — Initial: 7 tools, 4 generators, 6 exporters
+- v0.2.0 — AI interpretation layer for natural language refinement
+- v0.3.0 — Design system completeness: shadow, border, motion generators + exporter updates
 
 ## Open Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/branding-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/branding-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -741,9 +741,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3530,9 +3530,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4131,9 +4131,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5837,9 +5837,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7235,9 +7235,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Run `npm audit fix` to resolve minimatch ReDoS (GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74)
- 0 vulnerabilities remaining

## Test plan
- [ ] CI passes
- [ ] `npm audit` shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)