### PR TITLE
feat: Add generate_design_system combined MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-02-28
+
+### Added
+
+- New MCP tool: `generate_design_system` — complete design system in one call (identity + token export combined)
+- 10 new tests for design system tool (198 total across 16 suites)
+
 ## [0.4.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/Forge-Space/branding-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Forge-Space/branding-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Generate complete design systems — colors, typography, spacing, shadows, borders, motion tokens, gradients, multi-variant logos, favicons, and OG images with multi-format export. 8 MCP tools, zero API dependencies, algorithmic-first generation.
+Generate complete design systems — colors, typography, spacing, shadows, borders, motion tokens, gradients, multi-variant logos, favicons, and OG images with multi-format export. 9 MCP tools, zero API dependencies, algorithmic-first generation.
 
 ## Features
 
@@ -45,16 +45,17 @@ npm run build
 
 ### MCP Tools
 
-| Tool                         | Description                                        |
-| ---------------------------- | -------------------------------------------------- |
-| `generate_brand_identity`    | Complete brand from name, industry, and style      |
-| `generate_color_palette`     | Color palette with harmony and WCAG data           |
-| `generate_typography_system` | Font pairing + modular type scale                  |
-| `export_design_tokens`       | Export brand to JSON/CSS/Tailwind/Figma/React/Sass |
-| `create_brand_guidelines`    | Generate HTML brand book                           |
-| `validate_brand_consistency` | Check WCAG compliance and completeness             |
-| `refine_brand_element`       | Iterate on specific brand elements                 |
-| `generate_brand_assets`      | Generate favicons and OG images from brand         |
+| Tool                         | Description                                            |
+| ---------------------------- | ------------------------------------------------------ |
+| `generate_brand_identity`    | Complete brand from name, industry, and style          |
+| `generate_color_palette`     | Color palette with harmony and WCAG data               |
+| `generate_typography_system` | Font pairing + modular type scale                      |
+| `export_design_tokens`       | Export brand to JSON/CSS/Tailwind/Figma/React/Sass     |
+| `create_brand_guidelines`    | Generate HTML brand book                               |
+| `validate_brand_consistency` | Check WCAG compliance and completeness                 |
+| `refine_brand_element`       | Iterate on specific brand elements                     |
+| `generate_brand_assets`      | Generate favicons and OG images from brand             |
+| `generate_design_system`     | Complete design system in one call (identity + export) |
 
 ### MCP Resources
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/branding-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for AI-powered brand identity generation — color palettes, typography systems, design tokens, and brand guidelines with multi-format export",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/unit/design-system-tool.test.ts
+++ b/src/__tests__/unit/design-system-tool.test.ts
@@ -1,0 +1,176 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerGenerateDesignSystem } from '../../tools/generate-design-system.js';
+
+function createMockServer(): McpServer & { registeredTools: Map<string, unknown> } {
+  const tools = new Map<string, unknown>();
+  return {
+    registeredTools: tools,
+    tool(name: string, _desc: string, _schema: unknown, handler: unknown) {
+      tools.set(name, handler);
+    },
+  } as McpServer & { registeredTools: Map<string, unknown> };
+}
+
+describe('generate_design_system tool', () => {
+  let server: ReturnType<typeof createMockServer>;
+  let handler: (
+    params: Record<string, unknown>
+  ) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+
+  beforeAll(() => {
+    server = createMockServer();
+    registerGenerateDesignSystem(server);
+    handler = server.registeredTools.get('generate_design_system') as typeof handler;
+  });
+
+  it('registers the tool', () => {
+    expect(server.registeredTools.has('generate_design_system')).toBe(true);
+  });
+
+  it('generates identity with all subsystems', async () => {
+    const result = await handler({
+      brandName: 'TestBrand',
+      industry: 'tech',
+      style: 'minimal',
+      exportFormats: ['json'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    const identity = output.identity;
+
+    expect(identity.name).toBe('TestBrand');
+    expect(identity.colors).toBeDefined();
+    expect(identity.typography).toBeDefined();
+    expect(identity.spacing).toBeDefined();
+    expect(identity.shadows).toBeDefined();
+    expect(identity.borders).toBeDefined();
+    expect(identity.motion).toBeDefined();
+    expect(identity.gradients).toBeDefined();
+    expect(identity.logo).toBeDefined();
+  });
+
+  it('includes requested export formats', async () => {
+    const result = await handler({
+      brandName: 'TestBrand',
+      industry: 'tech',
+      style: 'bold',
+      exportFormats: ['css', 'tailwind'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.exports.css).toBeDefined();
+    expect(output.exports.tailwind).toBeDefined();
+    expect(output.exports.json).toBeUndefined();
+  });
+
+  it('exports valid CSS variables', async () => {
+    const result = await handler({
+      brandName: 'CSSTest',
+      industry: 'design',
+      style: 'elegant',
+      exportFormats: ['css'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.exports.css).toContain('--');
+    expect(output.exports.css).toContain(':root');
+  });
+
+  it('exports valid Tailwind preset', async () => {
+    const result = await handler({
+      brandName: 'TailwindTest',
+      industry: 'tech',
+      style: 'tech',
+      exportFormats: ['tailwind'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.exports.tailwind).toContain('theme');
+    expect(output.exports.tailwind).toContain('extend');
+  });
+
+  it('supports all 6 export formats at once', async () => {
+    const result = await handler({
+      brandName: 'AllFormats',
+      industry: 'retail',
+      style: 'playful',
+      exportFormats: ['json', 'css', 'tailwind', 'figma', 'react', 'sass'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(Object.keys(output.exports)).toHaveLength(6);
+  });
+
+  it('applies optional parameters', async () => {
+    const result = await handler({
+      brandName: 'CustomBrand',
+      industry: 'health',
+      style: 'organic',
+      tagline: 'Live naturally',
+      baseColor: '#2D8B4E',
+      harmony: 'analogous',
+      theme: 'light',
+      headingCategory: 'serif',
+      bodyCategory: 'sans-serif',
+      scaleRatio: 'golden-ratio',
+      exportFormats: ['json'],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.identity.tagline).toBe('Live naturally');
+    expect(output.identity.style).toBe('organic');
+  });
+
+  it('returns error for invalid input gracefully', async () => {
+    const result = await handler({
+      brandName: 'Test',
+      industry: 'tech',
+      style: 'minimal',
+      exportFormats: ['json'],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBeDefined();
+  });
+
+  it('generates unique brand IDs', async () => {
+    const params = {
+      brandName: 'UniqueTest',
+      industry: 'tech',
+      style: 'minimal' as const,
+      exportFormats: ['json'],
+    };
+
+    const r1 = await handler(params);
+    const r2 = await handler(params);
+    const id1 = JSON.parse(r1.content[0].text).identity.id;
+    const id2 = JSON.parse(r2.content[0].text).identity.id;
+    expect(id1).not.toBe(id2);
+  });
+
+  it('all brand styles produce valid output', async () => {
+    const styles = [
+      'minimal',
+      'bold',
+      'elegant',
+      'playful',
+      'corporate',
+      'tech',
+      'organic',
+      'retro',
+    ];
+
+    for (const style of styles) {
+      const result = await handler({
+        brandName: `${style}Brand`,
+        industry: 'test',
+        style,
+        exportFormats: ['json'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const output = JSON.parse(result.content[0].text);
+      expect(output.identity.style).toBe(style);
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerCreateBrandGuidelines } from './tools/create-brand-guidelines.j
 import { registerValidateBrandConsistency } from './tools/validate-brand-consistency.js';
 import { registerRefineBrandElement } from './tools/refine-brand-element.js';
 import { registerGenerateBrandAssets } from './tools/generate-brand-assets.js';
+import { registerGenerateDesignSystem } from './tools/generate-design-system.js';
 
 import { registerBrandTemplates } from './resources/brand-templates.js';
 import { registerBrandKnowledge } from './resources/brand-knowledge.js';
@@ -34,6 +35,7 @@ async function main(): Promise<void> {
   registerValidateBrandConsistency(server);
   registerRefineBrandElement(server);
   registerGenerateBrandAssets(server);
+  registerGenerateDesignSystem(server);
 
   registerBrandTemplates(server);
   registerBrandKnowledge(server);

--- a/src/tools/generate-design-system.ts
+++ b/src/tools/generate-design-system.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  generateColorPalette,
+  generateTypographySystem,
+  generateSpacingScale,
+  generateShadowSystem,
+  generateBorderSystem,
+  generateMotionSystem,
+  generateGradientSystem,
+  generateSvgLogo,
+  defaultLogoConfig,
+  exportDesignTokens,
+  exportCssVariables,
+  exportTailwindPreset,
+  exportFigmaTokens,
+  exportReactTheme,
+  exportSassVariables,
+} from '../lib/branding-core/index.js';
+import {
+  brandStyleSchema,
+  colorHarmonySchema,
+  colorThemeSchema,
+  exportFormatSchema,
+  fontCategorySchema,
+  hexColorSchema,
+  typeScaleRatioSchema,
+} from '../lib/branding-core/validators/token-schema.js';
+import type { BrandIdentity, BrandStyle, ExportFormat, FontCategory } from '../lib/types.js';
+import { logger } from '../lib/logger.js';
+
+const STYLE_DEFAULTS: Record<BrandStyle, { heading: FontCategory; body: FontCategory }> = {
+  minimal: { heading: 'sans-serif', body: 'sans-serif' },
+  bold: { heading: 'display', body: 'sans-serif' },
+  elegant: { heading: 'serif', body: 'serif' },
+  playful: { heading: 'display', body: 'sans-serif' },
+  corporate: { heading: 'sans-serif', body: 'sans-serif' },
+  tech: { heading: 'sans-serif', body: 'monospace' },
+  organic: { heading: 'serif', body: 'sans-serif' },
+  retro: { heading: 'display', body: 'serif' },
+};
+
+const EXPORTERS: Record<ExportFormat, (brand: BrandIdentity) => string | object> = {
+  json: exportDesignTokens,
+  css: exportCssVariables,
+  tailwind: exportTailwindPreset,
+  figma: exportFigmaTokens,
+  react: exportReactTheme,
+  sass: exportSassVariables,
+};
+
+function buildIdentity(params: {
+  brandName: string;
+  industry: string;
+  style: BrandStyle;
+  tagline?: string;
+  baseColor?: string;
+  harmony?: string;
+  theme?: string;
+  headingCategory?: FontCategory;
+  bodyCategory?: FontCategory;
+  scaleRatio?: string;
+}): BrandIdentity {
+  const defaults = STYLE_DEFAULTS[params.style];
+  const harmony = (params.harmony ?? 'complementary') as Parameters<typeof generateColorPalette>[1];
+  const theme = params.theme as Parameters<typeof generateColorPalette>[2];
+  const scaleRatio = (params.scaleRatio ?? 'major-third') as Parameters<
+    typeof generateTypographySystem
+  >[2];
+
+  const colors = generateColorPalette(params.baseColor, harmony, theme);
+  const typography = generateTypographySystem(
+    params.headingCategory ?? defaults.heading,
+    params.bodyCategory ?? defaults.body,
+    scaleRatio
+  );
+  const spacing = generateSpacingScale();
+  const shadows = generateShadowSystem(colors.primary.hex, theme);
+  const borders = generateBorderSystem(params.style);
+  const motion = generateMotionSystem(params.style);
+  const gradients = generateGradientSystem(colors, params.style);
+  const logoConfig = {
+    ...defaultLogoConfig(params.brandName, colors.primary.hex),
+    font: typography.headingFont,
+    style: params.style,
+  };
+  const logo = generateSvgLogo(logoConfig);
+
+  return {
+    id: `brand_${randomUUID().slice(0, 8)}`,
+    name: params.brandName,
+    tagline: params.tagline,
+    industry: params.industry,
+    style: params.style,
+    colors,
+    typography,
+    spacing,
+    shadows,
+    borders,
+    motion,
+    gradients,
+    logo,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function registerGenerateDesignSystem(server: McpServer): void {
+  server.tool(
+    'generate_design_system',
+    'Generate a complete design system with brand identity and exported tokens in one call. ' +
+      'Combines generate_brand_identity + export_design_tokens for a streamlined workflow.',
+    {
+      brandName: z.string().min(1).max(100).describe('Brand name'),
+      industry: z.string().min(1).max(100).describe('Industry or sector'),
+      style: brandStyleSchema.describe('Visual style direction'),
+      tagline: z.string().max(200).optional().describe('Brand tagline'),
+      baseColor: hexColorSchema.optional().describe('Base color preference'),
+      harmony: colorHarmonySchema.optional().describe('Color harmony type'),
+      theme: colorThemeSchema.optional().describe('Light/dark/both'),
+      headingCategory: fontCategorySchema.optional().describe('Heading font category'),
+      bodyCategory: fontCategorySchema.optional().describe('Body font category'),
+      scaleRatio: typeScaleRatioSchema.optional().describe('Typography scale ratio'),
+      exportFormats: z
+        .array(exportFormatSchema)
+        .min(1)
+        .max(6)
+        .describe('Token export formats to include'),
+    },
+    async (params) => {
+      try {
+        logger.info(
+          { brandName: params.brandName, formats: params.exportFormats },
+          'Generating design system'
+        );
+
+        const identity = buildIdentity(params);
+        const exports: Record<string, string> = {};
+
+        for (const format of params.exportFormats) {
+          const exporter = EXPORTERS[format];
+          const result = exporter(identity);
+          exports[format] = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+        }
+
+        const output = {
+          identity,
+          exports,
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error generating design system: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- New `generate_design_system` MCP tool combining brand identity generation + multi-format token export in one call
- Accepts all brand params (name, industry, style, colors, typography) plus `exportFormats` array
- Returns both the full `BrandIdentity` object and exported tokens in requested formats
- Uses `crypto.randomUUID()` for ID generation (CodeQL-compliant)
- 10 new tests (198 total across 16 suites)
- Version bump: 0.4.0 → 0.5.0

## Test plan
- [x] `npm run validate` passes (lint + format + 198 tests)
- [x] All 8 brand styles produce valid output
- [x] All 6 export formats work (JSON, CSS, Tailwind, Figma, React, Sass)
- [x] Optional parameters applied correctly
- [x] Unique IDs generated per call

🤖 Generated with [Claude Code](https://claude.com/claude-code)