### PR TITLE
feat: Export brand identity types from package entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-03-01
+
+### Added
+
+- Public type exports from package entry point: `BrandIdentity`, `ColorPalette`, `TypographySystem`, `SpacingScale`, `ShadowSystem`, `BorderSystem`, `MotionSystem`, `GradientSystem`, `LogoOutput`, `BrandStyle`, `ColorHarmony`, `ExportFormat`
+- Enables downstream packages (`@forgespace/brand-guide`) to re-export types without reaching into internal paths
+
 ## [0.5.0] - 2026-02-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/branding-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server for AI-powered brand identity generation — color palettes, typography systems, design tokens, and brand guidelines with multi-format export",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,20 @@
 #!/usr/bin/env node
 
+export type {
+  BrandIdentity,
+  ColorPalette,
+  TypographySystem,
+  SpacingScale,
+  ShadowSystem,
+  BorderSystem,
+  MotionSystem,
+  GradientSystem,
+  LogoOutput,
+  BrandStyle,
+  ColorHarmony,
+  ExportFormat,
+} from './lib/types.js';
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig } from './lib/config.js';


### PR DESCRIPTION
## Summary
- Export 12 brand identity types (`BrandIdentity`, `ColorPalette`, `TypographySystem`, etc.) from package entry point
- Enables downstream packages (`@forgespace/brand-guide`) to re-export types without internal path imports
- Bump version to v0.6.0

## Test plan
- [x] `npm run build` — `dist/index.d.ts` contains all type exports
- [x] `npm test` — 198 tests pass (16 suites)
- [ ] Tag v0.6.0 after merge → npm publish via release-automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)