### PR TITLE
fix: WCAG AA contrast compliance for brand colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.2] - 2026-03-07
+
+### Fixed
+
+- **WCAG contrast compliance** — Secondary (#3B82F6→#2563EB) and accent (#F59E0B→#B45309) colors now pass AA 4.5:1 on white backgrounds. Brand consistency score 75→100
+
 ## [0.6.1] - 2026-03-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/branding-mcp",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "MCP server for AI-powered brand identity generation — color palettes, typography systems, design tokens, and brand guidelines with multi-format export",
   "type": "module",
   "main": "dist/index.js",

--- a/src/resources/brand-templates.ts
+++ b/src/resources/brand-templates.ts
@@ -73,14 +73,14 @@ const FORGE_SPACE_BRAND: BrandIdentity = {
     },
     secondary: {
       name: 'Forge Blue',
-      hex: '#3B82F6',
-      hsl: { h: 217, s: 91, l: 60 },
+      hex: '#2563EB',
+      hsl: { h: 217, s: 83, l: 53 },
       usage: 'Secondary brand color',
     },
     accent: {
       name: 'Forge Amber',
-      hex: '#F59E0B',
-      hsl: { h: 43, s: 96, l: 50 },
+      hex: '#B45309',
+      hsl: { h: 33, s: 92, l: 37 },
       usage: 'Accent and highlight color',
     },
     neutral: [
@@ -157,8 +157,8 @@ const FORGE_SPACE_BRAND: BrandIdentity = {
     contrast: {
       'primary-on-white': { ratio: 5.67, aa: true, aaLarge: true, aaa: false, aaaLarge: true },
       'primary-on-dark': { ratio: 3.07, aa: false, aaLarge: true, aaa: false, aaaLarge: false },
-      'secondary-on-white': { ratio: 4.35, aa: false, aaLarge: true, aaa: false, aaaLarge: false },
-      'accent-on-white': { ratio: 3.52, aa: false, aaLarge: true, aaa: false, aaaLarge: false },
+      'secondary-on-white': { ratio: 5.17, aa: true, aaLarge: true, aaa: false, aaaLarge: true },
+      'accent-on-white': { ratio: 5.02, aa: true, aaLarge: true, aaa: false, aaaLarge: true },
     },
   },
   typography: {


### PR DESCRIPTION
## Summary
- Secondary (#3B82F6 → #2563EB): 3.68:1 → 5.17:1 on white
- Accent (#F59E0B → #B45309): 2.15:1 → 5.02:1 on white
- Brand consistency validation score: 75 → 100

## Test plan
- [x] All 198 tests pass
- [ ] CI: Lint & Format, Test (Node 22/24), Type Check, Build