### PR TITLE
feat: add healthcare output contract exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ export type {
   BrandB2bOutput,
   BrandSaasOutput,
   BrandFintechOutput,
+  BrandHealthcareOutput,
 } from './lib/types.js';
 
 import { parseArgs } from 'node:util';

--- a/src/lib/branding-core/index.ts
+++ b/src/lib/branding-core/index.ts
@@ -33,6 +33,7 @@ export { interpretWithKeywords } from './ai/keyword-interpreter.js';
 export { applyIntent } from './ai/intent-applier.js';
 export type { BrandIntent, ColorIntent, TypographyIntent, InterpreterOptions } from './ai/types.js';
 export type { InterpreterStrategy } from './ai/brand-interpreter.js';
+export type { BrandHealthcareOutput } from '../types.js';
 export { generateBrandPhotography } from './generators/brand-photography.js';
 export { generateBrandCampaign } from './generators/brand-campaign.js';
 export { generateBrandPackaging } from './generators/brand-packaging.js';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1290,3 +1290,14 @@ export interface BrandFintechOutput {
   userJourney: string[];
   fintechBriefSummary: string;
 }
+
+export interface BrandHealthcareOutput {
+  positioning: string;
+  careSpecialties: string[];
+  trustSignals: string[];
+  regulatoryFramework: string[];
+  communicationPillars: string[];
+  patientJourney: string[];
+  accessibilityRequirements: string[];
+  healthcareBriefSummary: string;
+}


### PR DESCRIPTION
## Summary
- add a new `BrandHealthcareOutput` interface to the shared branding type contracts
- export `BrandHealthcareOutput` from `src/lib/branding-core/index.ts` as a type-only export
- re-export `BrandHealthcareOutput` from top-level `src/index.ts` so downstream consumers can import it directly

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for healthcare branding output type with healthcare-specific fields including positioning, care specialties, trust signals, regulatory framework, communication pillars, patient journey, accessibility requirements, and summary information.
  * New type is now publicly available across the library's export surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->