### PR TITLE
feat(healthcare): add healthcare brand output generator and MCP tool

### DIFF
--- a/src/__tests__/unit/brand-healthcare.test.ts
+++ b/src/__tests__/unit/brand-healthcare.test.ts
@@ -1,0 +1,81 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { generateColorPalette } from '../../lib/branding-core/generators/color-palette.js';
+import { generateTypographySystem } from '../../lib/branding-core/generators/typography-system.js';
+import { generateSpacingScale } from '../../lib/branding-core/generators/spacing-scale.js';
+import { generateBrandHealthcare } from '../../lib/branding-core/generators/brand-healthcare.js';
+import type { BrandIdentity } from '../../lib/types.js';
+
+function createTestBrand(overrides: Partial<BrandIdentity> = {}): BrandIdentity {
+  const colors = generateColorPalette('#22C55E', 'analogous');
+  const typography = generateTypographySystem('sans-serif', 'serif');
+  const spacing = generateSpacingScale(4);
+
+  return {
+    id: 'health-brand',
+    name: 'CareFlow',
+    tagline: 'Clarity for every patient',
+    industry: 'healthcare services',
+    style: 'tech',
+    colors,
+    typography,
+    spacing,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('generateBrandHealthcare', () => {
+  let brand: BrandIdentity;
+
+  beforeAll(() => {
+    brand = createTestBrand();
+  });
+
+  it('returns all required fields', () => {
+    const result = generateBrandHealthcare(brand);
+    expect(result.positioning).toBeTruthy();
+    expect(result.careSpecialties).toBeDefined();
+    expect(result.trustSignals).toBeDefined();
+    expect(result.regulatoryFramework).toBeDefined();
+    expect(result.communicationPillars).toBeDefined();
+    expect(result.accessibilityRequirements).toBeDefined();
+    expect(result.patientJourney).toBeDefined();
+    expect(result.healthcareBriefSummary).toBeTruthy();
+  });
+
+  it('includes at least 3 care specialties', () => {
+    const result = generateBrandHealthcare(brand);
+    expect(result.careSpecialties.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('tech style includes digital triage in patient journey', () => {
+    const result = generateBrandHealthcare(brand);
+    const hasDigitalTriage = result.patientJourney.some((step) =>
+      step.toLowerCase().includes('digital triage')
+    );
+    expect(hasDigitalTriage).toBe(true);
+  });
+
+  it('corporate style includes enterprise trust language', () => {
+    const corp = createTestBrand({ style: 'corporate' });
+    const result = generateBrandHealthcare(corp);
+    const hasEnterpriseTrust = result.trustSignals.some((signal) =>
+      signal.toLowerCase().includes('enterprise')
+    );
+    expect(hasEnterpriseTrust).toBe(true);
+  });
+
+  it('unknown style falls back to minimal strategy', () => {
+    const unknown = createTestBrand({ style: 'unknown' as never });
+    const result = generateBrandHealthcare(unknown);
+    expect(result.positioning.toLowerCase()).toContain('clear, calm');
+    expect(result.regulatoryFramework.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('summary includes brand name and excludes undefined tagline', () => {
+    const noTag = createTestBrand({ tagline: undefined });
+    const result = generateBrandHealthcare(noTag);
+    expect(result.healthcareBriefSummary).toContain('CareFlow');
+    expect(result.healthcareBriefSummary).not.toContain('undefined');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,7 @@ import { registerGenerateBrandSubscription } from './tools/generate-brand-subscr
 import { registerGenerateBrandB2b } from './tools/generate-brand-b2b.js';
 import { registerGenerateBrandSaas } from './tools/generate-brand-saas.js';
 import { registerGenerateBrandFintech } from './tools/generate-brand-fintech.js';
+import { registerGenerateBrandHealthcare } from './tools/generate-brand-healthcare.js';
 
 import { registerBrandTemplates } from './resources/brand-templates.js';
 import { registerBrandKnowledge } from './resources/brand-knowledge.js';
@@ -260,6 +261,7 @@ async function main(): Promise<void> {
   registerGenerateBrandB2b(server);
   registerGenerateBrandSaas(server);
   registerGenerateBrandFintech(server);
+  registerGenerateBrandHealthcare(server);
 
   registerBrandTemplates(server);
   registerBrandKnowledge(server);

--- a/src/lib/branding-core/generators/brand-healthcare.ts
+++ b/src/lib/branding-core/generators/brand-healthcare.ts
@@ -1,0 +1,194 @@
+import type { BrandHealthcareOutput, BrandIdentity, BrandStyle } from '../../types.js';
+
+const VALID_STYLES = new Set<BrandStyle>([
+  'minimal',
+  'bold',
+  'elegant',
+  'playful',
+  'corporate',
+  'tech',
+  'organic',
+  'retro',
+]);
+
+const STYLE_POSITIONING: Record<BrandStyle, string> = {
+  minimal: 'Clear, calm healthcare experiences focused on patient confidence and low friction.',
+  bold: 'High-impact healthcare brand accelerating access, outcomes, and modern care delivery.',
+  elegant: 'Premium care experience combining medical rigor with concierge-level patient service.',
+  playful: 'Warm, approachable care brand that reduces anxiety through supportive guidance.',
+  corporate: 'Enterprise-grade healthcare platform trusted by hospitals, insurers, and regulators.',
+  tech: 'Data-informed healthcare infrastructure built for clinicians, operators, and digital teams.',
+  organic: 'Human-centered healthcare rooted in prevention, wellbeing, and long-term trust.',
+  retro: 'Community-first care model inspired by timeless bedside values and continuity of care.',
+};
+
+const STYLE_CARE_SEGMENTS: Record<BrandStyle, string[]> = {
+  minimal: ['Primary care', 'Preventive screenings', 'Chronic care follow-up'],
+  bold: ['Urgent virtual consults', 'Rapid specialty referrals', 'Outcome-based programs'],
+  elegant: ['Executive health', 'Specialist concierge', 'Personalized prevention plans'],
+  playful: ['Family care', 'Adolescent health coaching', 'Lifestyle medicine support'],
+  corporate: ['Health systems', 'Employer health programs', 'Payer-provider partnerships'],
+  tech: ['Digital triage', 'Remote patient monitoring', 'Care operations analytics'],
+  organic: ['Whole-person wellness', 'Behavioral health support', 'Community prevention clinics'],
+  retro: ['Neighborhood clinics', 'Longitudinal family medicine', 'In-person continuity plans'],
+};
+
+const STYLE_TRUST_SIGNALS: Record<BrandStyle, string[]> = {
+  minimal: ['HIPAA-aligned workflows', 'Transparent consent language', 'Published care standards'],
+  bold: [
+    '24/7 clinical escalation pathways',
+    'Documented outcome improvements',
+    'Rapid callback SLAs',
+  ],
+  elegant: [
+    'Board-certified specialist network',
+    'Private care coordination',
+    'Dedicated care navigator',
+  ],
+  playful: ['Friendly patient education', 'Simple care plans', 'High patient satisfaction scores'],
+  corporate: ['SOC 2 Type II controls', 'Enterprise BAA readiness', 'Formal quality governance'],
+  tech: ['Audit-ready event logging', 'Role-based access controls', 'Clinical safety guardrails'],
+  organic: [
+    'Evidence-based care pathways',
+    'Community advisory board',
+    'Inclusive care principles',
+  ],
+  retro: [
+    'Long-term clinician relationships',
+    'Continuity handoff protocols',
+    'Local trust reputation',
+  ],
+};
+
+const STYLE_REGULATORY_FRAMEWORK: Record<BrandStyle, string[]> = {
+  minimal: ['HIPAA', 'GDPR (where applicable)', 'Informed consent', 'Data retention policy'],
+  bold: [
+    'HIPAA',
+    'Telehealth state licensure checks',
+    'Clinical documentation policy',
+    'Incident response',
+  ],
+  elegant: ['HIPAA', 'ISO 27001 controls', 'Clinical governance board', 'Third-party risk reviews'],
+  playful: [
+    'HIPAA',
+    'Age-appropriate consent processes',
+    'Accessibility policy',
+    'Safety incident playbook',
+  ],
+  corporate: ['HIPAA', 'HITRUST-aligned controls', 'SOC 2 Type II', 'Vendor BAA program'],
+  tech: ['HIPAA', 'Secure SDLC controls', 'PHI data minimization', 'Audit trail retention'],
+  organic: [
+    'HIPAA',
+    'Privacy-by-design reviews',
+    'Community health reporting standards',
+    'Ethical data use',
+  ],
+  retro: [
+    'HIPAA',
+    'Legacy records governance',
+    'Care continuity documentation',
+    'Escalation protocols',
+  ],
+};
+
+const STYLE_SERVICE_MODEL: Record<BrandStyle, string[]> = {
+  minimal: ['Self-scheduling', 'Asynchronous follow-up', 'Clear referral handoff'],
+  bold: ['Omnichannel triage', 'Rapid specialist routing', 'Outcome review cadences'],
+  elegant: ['Dedicated care coordinator', 'White-glove scheduling', 'Proactive follow-up outreach'],
+  playful: ['Guided check-ins', 'Family-oriented care touchpoints', 'Simple plan reminders'],
+  corporate: [
+    'Integrated care operations',
+    'Multi-site governance workflows',
+    'Standardized care pathways',
+  ],
+  tech: [
+    'API-connected care orchestration',
+    'Device and data integrations',
+    'Automated risk flagging',
+  ],
+  organic: [
+    'Prevention-first programs',
+    'Community partner referrals',
+    'Longitudinal wellbeing plans',
+  ],
+  retro: ['Clinic-first care plans', 'Local specialist networks', 'Phone-first follow-up options'],
+};
+
+function buildPatientSafetyProtocols(safeStyle: BrandStyle): string[] {
+  const base = [
+    'Clinical escalation matrix for red-flag symptoms',
+    'Medication and allergy verification checkpoints',
+    'Closed-loop follow-up for unresolved cases',
+    'Patient identity verification before care actions',
+  ];
+  if (safeStyle === 'tech' || safeStyle === 'corporate') {
+    base.push('Automated high-risk alert routing to on-call clinicians');
+  }
+  if (safeStyle === 'elegant' || safeStyle === 'organic') {
+    base.push('Proactive care coordination review for complex patients');
+  }
+  return base;
+}
+
+function buildCommunicationPillars(safeStyle: BrandStyle): string[] {
+  return [...buildPatientSafetyProtocols(safeStyle), ...STYLE_SERVICE_MODEL[safeStyle]];
+}
+
+function buildAccessibilityCommitments(safeStyle: BrandStyle): string[] {
+  const base = [
+    'Plain-language care communication',
+    'WCAG-aligned digital experiences',
+    'Language support for key patient populations',
+  ];
+  if (safeStyle === 'playful' || safeStyle === 'organic') {
+    base.push('Care education materials tailored to health literacy levels');
+  }
+  if (safeStyle === 'corporate' || safeStyle === 'tech') {
+    base.push('Accessible-by-default product review in release process');
+  }
+  return base;
+}
+
+function buildPatientJourney(safeStyle: BrandStyle): string[] {
+  const base = [
+    'Awareness and trusted referral',
+    'Eligibility and intake capture',
+    'Clinical assessment and care planning',
+    'Treatment or intervention delivery',
+    'Follow-up and adherence support',
+    'Outcome review and continuity planning',
+  ];
+  if (safeStyle === 'tech') {
+    base.splice(2, 0, 'Digital triage with risk stratification');
+  }
+  if (safeStyle === 'elegant') {
+    base.splice(4, 0, 'Concierge coordinator check-in');
+  }
+  return base;
+}
+
+function buildHealthcareBriefSummary(brand: BrandIdentity, safeStyle: BrandStyle): string {
+  const taglinePart = brand.tagline ? ` - "${brand.tagline}"` : '';
+  const segment = STYLE_CARE_SEGMENTS[safeStyle][0];
+  const trust = STYLE_TRUST_SIGNALS[safeStyle][0];
+  return (
+    `${brand.name}${taglinePart} is a ${safeStyle}-style healthcare brand in ${brand.industry}. ` +
+    `Positioning: ${STYLE_POSITIONING[safeStyle]} Primary care segment: ${segment}. ` +
+    `Core trust signal: ${trust}.`
+  );
+}
+
+export function generateBrandHealthcare(brand: BrandIdentity): BrandHealthcareOutput {
+  const safeStyle: BrandStyle = VALID_STYLES.has(brand.style) ? brand.style : 'minimal';
+
+  return {
+    positioning: STYLE_POSITIONING[safeStyle],
+    careSpecialties: STYLE_CARE_SEGMENTS[safeStyle],
+    trustSignals: STYLE_TRUST_SIGNALS[safeStyle],
+    regulatoryFramework: STYLE_REGULATORY_FRAMEWORK[safeStyle],
+    communicationPillars: buildCommunicationPillars(safeStyle),
+    accessibilityRequirements: buildAccessibilityCommitments(safeStyle),
+    patientJourney: buildPatientJourney(safeStyle),
+    healthcareBriefSummary: buildHealthcareBriefSummary(brand, safeStyle),
+  };
+}

--- a/src/lib/branding-core/index.ts
+++ b/src/lib/branding-core/index.ts
@@ -79,3 +79,4 @@ export { generateBrandSubscription } from './generators/brand-subscription.js';
 export { generateBrandB2b } from './generators/brand-b2b.js';
 export { generateBrandSaas } from './generators/brand-saas.js';
 export { generateBrandFintech } from './generators/brand-fintech.js';
+export { generateBrandHealthcare } from './generators/brand-healthcare.js';

--- a/src/tools/generate-brand-healthcare.ts
+++ b/src/tools/generate-brand-healthcare.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { generateBrandHealthcare } from '../lib/branding-core/index.js';
+import type { BrandIdentity } from '../lib/types.js';
+
+export function registerGenerateBrandHealthcare(server: McpServer): void {
+  server.tool(
+    'generate_brand_healthcare',
+    'Generate healthcare-specific brand strategy covering care segments, patient safety, service delivery, and compliance posture.',
+    {
+      brand: z.string().describe('JSON string of BrandIdentity object'),
+    },
+    async ({ brand }) => {
+      let brandData: BrandIdentity;
+
+      try {
+        brandData = JSON.parse(brand) as BrandIdentity;
+      } catch {
+        throw new Error('Invalid brand payload: expected a valid JSON string for BrandIdentity.');
+      }
+
+      const result = generateBrandHealthcare(brandData);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add  contract and healthcare strategy generator with deterministic style mappings
- register new MCP tool  and expose generator/type through module exports
- add unit tests covering output shape, style-specific behavior, fallback logic, and summary generation

## Validation
- 
> @forgespace/branding-mcp@0.55.3 lint:check
> eslint .
- 
> @forgespace/branding-mcp@0.55.3 typecheck
> tsc --noEmit
- 
> @forgespace/branding-mcp@0.55.3 test
> NODE_OPTIONS=--experimental-vm-modules jest brand-healthcare