### PR TITLE
test: add bin-entries regression guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:check": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "pretest": "npm run build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:check": "prettier --check .",
     "pretest": "npm run build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "pretest:coverage": "npm run build",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "typecheck": "tsc --noEmit",

--- a/src/__tests__/bin-entries.test.ts
+++ b/src/__tests__/bin-entries.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')) as {
+  name: string;
+  bin?: string | Record<string, string>;
+  files?: string[];
+};
+
+function normalizeBin(bin: typeof pkg.bin, name: string): Array<[string, string]> {
+  if (typeof bin === 'string') return [[name, bin]];
+  if (bin && typeof bin === 'object') return Object.entries(bin);
+  return [];
+}
+
+function pkgFilesCoversPath(files: string[], relPath: string): boolean {
+  const clean = relPath.replace(/^\.\//, '');
+  const top = clean.split('/')[0];
+  return files.some((f) => {
+    const c = f.replace(/\/$/, '').replace(/^\.\//, '');
+    return c === top;
+  });
+}
+
+describe('package.json bin entries', () => {
+  const entries = normalizeBin(pkg.bin, pkg.name);
+  const files: string[] = pkg.files ?? [];
+
+  it('declares at least one bin entry', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" exists on disk', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    expect(existsSync(abs)).toBe(true);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" starts with a node shebang', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    if (!existsSync(abs)) return;
+    const firstLine = readFileSync(abs, 'utf-8').split('\n', 1)[0] ?? '';
+    expect(firstLine).toMatch(/^#!.*\bnode\b/);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" lives under a directory in pkg.files', (_name, rel) => {
+    expect(pkgFilesCoversPath(files, rel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a parameterised regression guard test that validates every `pkg.bin` entry on disk:
- Existence check (file exists)
- Node shebang verification (`#!/usr/bin/env node`)
- Package.files coverage (bin target lives under a packaged directory)

## Why

`@forgespace/core` shipped v1.4.0-v1.14.0 with `bin.forge-patterns` pointing to a non-existent `dist/cli.js` for over a year. This regression was caught only during PR #202, which added the same guard. Rolling it out across all Forge Space npm packages with bin blocks to prevent recurrence.

## Test Plan

1. Local build + test passes: `npm run build && npm test -- src/__tests__/bin-entries.test.ts` → 4 tests passing
2. Mutation test: Temporarily point `package.json:bin.forgespace-branding-mcp` to `dist/does-not-exist.js` → test fails as expected ✓
3. Restore correct path → test passes ✓

## Reference

See Forge-Space/core#202 for the original implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for package binary configuration.

* **Chores**
  * Added automatic build step before test execution to ensure code is compiled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->