### PR TITLE
fix(scripts): mcp-registry-status picks oldest version + surfaces lookup errors

### DIFF
--- a/scripts/mcp-registry-status.mjs
+++ b/scripts/mcp-registry-status.mjs
@@ -36,15 +36,44 @@ function normalizeRepoUrl(url = '') {
     .replace(/\/$/, '');
 }
 
-function pickRegistryEntry(results, server) {
-  return (
-    results.servers?.find((item) => item.server?.name === server.name) ??
-    results.servers?.find(
-      (item) =>
-        normalizeRepoUrl(item.server?.repository?.url) === normalizeRepoUrl(server.repository?.url)
-    ) ??
-    null
+// Simple semver comparator. Returns positive if a > b, negative if a < b, 0 if equal.
+// Handles major.minor.patch only — prerelease tags are compared lexicographically as a tiebreaker.
+function compareSemver(a = '', b = '') {
+  const parse = (v) => {
+    const [core, pre = ''] = String(v).split('-', 2);
+    const nums = core.split('.').map((n) => Number.parseInt(n, 10) || 0);
+    return { nums: [nums[0] ?? 0, nums[1] ?? 0, nums[2] ?? 0], pre };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (pa.nums[i] !== pb.nums[i]) return pa.nums[i] - pb.nums[i];
+  }
+  if (pa.pre === pb.pre) return 0;
+  if (!pa.pre) return 1; // release > prerelease
+  if (!pb.pre) return -1;
+  return pa.pre < pb.pre ? -1 : 1;
+}
+
+function pickLatest(matches) {
+  if (!matches.length) return null;
+  return matches.reduce((latest, item) =>
+    compareSemver(item.server?.version, latest.server?.version) > 0 ? item : latest
   );
+}
+
+function pickRegistryEntry(results, server) {
+  const servers = results.servers ?? [];
+  // The registry search endpoint returns versions in ascending order, so `.find()` would
+  // pick the OLDEST matching entry and cause false "republish needed" action items.
+  // We want the highest semver among matches instead.
+  const nameMatches = servers.filter((item) => item.server?.name === server.name);
+  if (nameMatches.length) return pickLatest(nameMatches);
+  const urlMatches = servers.filter(
+    (item) =>
+      normalizeRepoUrl(item.server?.repository?.url) === normalizeRepoUrl(server.repository?.url)
+  );
+  return pickLatest(urlMatches);
 }
 
 function buildActionItems(pkg, npmVersion, registryVersion, registryEntry, lookupErrors) {


### PR DESCRIPTION
## Summary

- **Pick latest registry version, not oldest** — the MCP Registry search endpoint returns matches in ascending semver order. The old \`.find()\` would pick the OLDEST entry and emit a false \"republish needed\" action item whenever multiple versions of the same server were indexed. Now uses a proper semver comparator + \`reduce\` to pick the highest.
- **Surface transient lookup failures** — the old \`.catch(() => null)\` silently swallowed npm/registry HTTP errors and then reported \"publish to npm\" as the action item even when the real problem was network flakiness. Errors are now captured per-lookup in \`report.lookupErrors\` and the action items show \`⚠ npm lookup failed — retry: …\` instead.
- **Fallback URL match** — when the server name doesn't match any entry, also try matching on normalized repository URL (strips \`git+\`, \`.git\`, trailing slash).

## Verification

\`\`\`bash
node scripts/mcp-registry-status.mjs --output-dir /tmp/verify
# report.md shows \"No action required\" when npm + registry are aligned
\`\`\`

## Test plan

- [x] Run locally → \"No action required. Package and MCP Registry metadata are aligned.\"
- [ ] Verify cron workflow emits clean report after merge