### PR TITLE
docs(specs): bootstrap spec and roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-branding-roadmap-specs**  _(proposed)_  `roadmap,specs,branding`
+- **2026-04-15-branding-roadmap-specs** _(proposed)_ `roadmap,specs,branding`
 
 ## Recently shipped
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap - branding-mcp
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-branding-roadmap-specs**  _(proposed)_  `roadmap,specs,branding`
+
+## Recently shipped
+
+_(none)_

--- a/docs/specs/2026-04-15-branding-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-branding-roadmap-specs/spec.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: roadmap,specs,branding
+---
+
+# branding-roadmap-specs
+
+## Goal
+Move Branding MCP feature planning into committed specs plus a generated roadmap.
+
+## Context
+Branding MCP work needs traceable design/tooling decisions. Specs give each improvement a small durable plan and task list.
+
+## Approach
+Add an initial proposed spec, generate docs/roadmap.md, and keep future branding improvements represented as specs before implementation.
+
+## Verification
+The generated roadmap shows the proposed branding spec and the spec content is indexed by RAG.

--- a/docs/specs/2026-04-15-branding-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-branding-roadmap-specs/spec.md
@@ -9,13 +9,17 @@ tags: roadmap,specs,branding
 # branding-roadmap-specs
 
 ## Goal
+
 Move Branding MCP feature planning into committed specs plus a generated roadmap.
 
 ## Context
+
 Branding MCP work needs traceable design/tooling decisions. Specs give each improvement a small durable plan and task list.
 
 ## Approach
+
 Add an initial proposed spec, generate docs/roadmap.md, and keep future branding improvements represented as specs before implementation.
 
 ## Verification
+
 The generated roadmap shows the proposed branding spec and the spec content is indexed by RAG.

--- a/docs/specs/2026-04-15-branding-roadmap-specs/tasks.md
+++ b/docs/specs/2026-04-15-branding-roadmap-specs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - branding-roadmap-specs
+
+- [ ] Review current roadmap/backlog signals for the repo
+- [ ] Convert the next non-trivial feature into a focused spec
+- [ ] Keep docs/roadmap.md generated from specs, not hand-edited
+- [ ] Verify RAG returns this spec via source_type=spec or roadmap
+- [ ] Link the implementation PR before marking shipped


### PR DESCRIPTION
## Summary
- seed Agent-OS-style feature spec placeholder
- generate docs/roadmap.md from spec frontmatter
- make the repo visible to the shared RAG spec/roadmap workflow

## Verification
- docs-only change; inspected generated roadmap and spec layout
